### PR TITLE
fix: requirements bigquery version

### DIFF
--- a/cf/requirements.txt
+++ b/cf/requirements.txt
@@ -1,5 +1,5 @@
 google-api-python-client==1.12.8
 google-cloud-storage==1.35.0
-google-cloud-bigquery==2.6.2
+google-cloud-bigquery==2.7.0
 google-cloud-pubsub==2.2.0
 pytest==6.2.1


### PR DESCRIPTION
Couldn’t install the version of BigQuery=2.6.2. 

Changed it to 2.7.0.

Below is the error I was getting:

![image](https://user-images.githubusercontent.com/45578394/108153278-0ff53480-7098-11eb-8a9c-8a586a5e559d.png)
